### PR TITLE
Fix for flow components without version number

### DIFF
--- a/buildpackage/tasks.py
+++ b/buildpackage/tasks.py
@@ -213,6 +213,7 @@ def query_components_from_org(package):
 			if not Component.objects.filter(component_type=component_type.id):
 				component_type.delete()
 
+		appendVersionNumForMissingFlows(package,metadata_client)
 		package.package = build_xml(package)
 
 		package.status = 'Finished'
@@ -224,6 +225,50 @@ def query_components_from_org(package):
 	package.finished_date = datetime.datetime.now()
 	package.save()
 
+
+def appendVersionNumForMissingFlows(package,metadata_client):
+
+	flowNamesList = getFlowNamesMissingVersionNum(package)
+
+	flowAndVersionNumObj = getActiveVersionNumForFlows(metadata_client,flowList)
+
+	flowComponentType = ComponentType.objects.filter(package=package.id,name='Flow')[0] #There will be only one flow component type per package.
+
+	#retrieve flow component row, append active version number row and save record.
+	for i in xrange(0,len(flowNamesList)):
+		component = flowComponentType.component_set.filter(name=flowNamesList[i])[0]
+		component.name = component.name + '-' + str(flowAndVersionNumObj[flowNamesList[i]])
+		component.save()
+
+def getActiveVersionNumForFlows(metadata_client,flowList):
+
+	# This variable is to store flow name as key and active version number as value.
+	flowAndVersionNumObj = dict()
+
+	#Prepare object with flow name as property and version number as value.
+	#step size here is 10 because readMetadata can accept only upto 10 component names at a time.
+	for i in xrange(0,len(flowNamesList),10):
+		for resultObj in metadata_client.service.readMetadata('FlowDefinition',flowNamesList[i:i+10]).records:
+			if resultObj:
+				flowAndVersionNumObj[resultObj.fullName] = resultObj.activeVersionNumber
+
+	return flowAndVersionNumObj
+
+def getFlowNamesMissingVersionNum(package):
+	endswithVersionNumregex = re.compile(r'-\d+$') #regex to check if flow name ends with version number
+
+	flowNamesList = []
+
+	flowComponentType = ComponentType.objects.filter(package=package.id,name='Flow')[0] #There will be only one flow component type per package.
+	flowComponentsList = flowComponentType.component_set.all()
+
+	for flowObj in flowComponentsList:
+		matches = endswithVersionNumregex.search(flowObj.name)
+
+		if matches is None: #No version number at the end for flow name.
+			flowNamesList.append(flowObj.name)
+
+	return flowNamesList
 
 def build_xml(package):
 	"""


### PR DESCRIPTION
@benedwards44 

listMetadata returns flow names without version number if flow is active but we need version number at the end to retrieve the flow.

To get the active version number for each flow, make another call to readMetadata with Metadata type as 'flowDefinition' and append the version number to flow.

Screenshot showing the actual problem:

![selection_099](https://user-images.githubusercontent.com/11079913/47672909-8ac57900-db89-11e8-9262-6f8d69a5ac55.jpg)

readMetadata call to get the active version number:
![selection_103](https://user-images.githubusercontent.com/11079913/47672950-a16bd000-db89-11e8-89e0-eaff61918417.jpg)

I made the changes to identify if there are any flows with version number missing at the end. If yes, it collects all those flows and makes call to readMetadata with size=10 and updates component with active version number at the end.

Let me know if you have any more questions.. Thanks!