### PR TITLE
Check if org has flows before doing processing

### DIFF
--- a/buildpackage/tasks.py
+++ b/buildpackage/tasks.py
@@ -214,7 +214,8 @@ def query_components_from_org(package):
 			if not Component.objects.filter(component_type=component_type.id):
 				component_type.delete()
 
-		appendVersionNumForMissingFlows(package,metadata_client)
+		if flowsExistInTheOrg(package):
+			appendVersionNumForMissingFlows(package,metadata_client)
 		package.package = build_xml(package)
 
 		package.status = 'Finished'
@@ -226,6 +227,8 @@ def query_components_from_org(package):
 	package.finished_date = datetime.datetime.now()
 	package.save()
 
+def flowsExistInTheOrg(package):
+	return len(ComponentType.objects.filter(package=package.id,name='Flow')) > 0
 
 def appendVersionNumForMissingFlows(package,metadata_client):
 


### PR DESCRIPTION
With the recent change added to get version number for flows, It is failing if org doesn't have flows as below. Added a check to see if org has flow components before calling the method to add version numbers.

![selection_134](https://user-images.githubusercontent.com/11079913/48656578-6fb19080-e9f4-11e8-98f9-c22f9009f2a5.jpg)
